### PR TITLE
Address issue 11

### DIFF
--- a/ENHANCED_PROFILE_SYSTEM.md
+++ b/ENHANCED_PROFILE_SYSTEM.md
@@ -1,0 +1,218 @@
+# Enhanced Profile System with Interactive Prompts
+
+## Overview
+
+The profile system has been enhanced to support interactive prompts as part of the profile metadata definition. This addresses the user's request to move the hardcoded interactive prompt sections into the profile schema, making the system more flexible and configurable.
+
+## Enhanced Profile Schema
+
+### New `InteractivePrompts` Section
+
+Each profile can now include an `InteractivePrompts` section that defines which services should prompt the user for configuration:
+
+```json
+{
+  "profileName": {
+    "StopServicesPre": [...],
+    "KillProcesses": [...],
+    "StartServicesPost": [...],
+    "LaunchAppsPost": [...],
+    "InteractivePrompts": {
+      "serviceTag": {
+        "enabled": true,
+        "title": "Service Display Name",
+        "description": "Detailed description of what this service does",
+        "question": "Custom question to ask the user (optional)",
+        "defaultNeeded": true
+      }
+    }
+  }
+}
+```
+
+### Interactive Prompt Configuration Fields
+
+- **`enabled`**: Boolean indicating whether this prompt should be shown
+- **`title`**: Display name for the service category
+- **`description`**: Detailed explanation of what the service does
+- **`question`**: Custom question to ask the user (optional - defaults to generic question)
+- **`defaultNeeded`**: Default value if user doesn't provide input
+
+## Supported Service Tags
+
+The system supports the following service tags for interactive prompts:
+
+- **`network`**: WiFi, network management, DHCP, DNS cache, network location awareness
+- **`audio`**: Audio services and audio device management
+- **`bluetooth`**: Bluetooth support services
+- **`ui`**: Theme and user interface services
+- **`storage-opt`**: Disk defragmentation, volume shadow copy services
+- **`telemetry`**: Diagnostic and telemetry services
+
+## Profile Examples
+
+### Normal Profile
+```json
+{
+  "normal": {
+    "InteractivePrompts": {
+      "network": {
+        "enabled": true,
+        "title": "Network Services",
+        "description": "These services manage your network connections and internet access.",
+        "question": "Do you need network services for normal use? (y/N)",
+        "defaultNeeded": true
+      },
+      "audio": {
+        "enabled": true,
+        "title": "Audio Services",
+        "description": "These services manage audio playback and recording.",
+        "question": "Do you need audio services for normal use? (y/N)",
+        "defaultNeeded": true
+      },
+      "bluetooth": {
+        "enabled": true,
+        "title": "Bluetooth Services",
+        "description": "These services manage Bluetooth devices and connections.",
+        "question": "Do you need Bluetooth services for normal use? (y/N)",
+        "defaultNeeded": false
+      }
+    }
+  }
+}
+```
+
+### Gaming Profile
+```json
+{
+  "gaming": {
+    "InteractivePrompts": {
+      "audio": {
+        "enabled": true,
+        "title": "Audio Services",
+        "description": "These services manage audio playback and recording.",
+        "question": "Do you need audio services for gaming? (y/N)",
+        "defaultNeeded": true
+      },
+      "network": {
+        "enabled": true,
+        "title": "Network Services",
+        "description": "These services manage your network connections and internet access.",
+        "question": "Do you need network services for gaming? (y/N)",
+        "defaultNeeded": true
+      }
+    }
+  }
+}
+```
+
+### Development Profile
+```json
+{
+  "dev": {
+    "InteractivePrompts": {
+      "network": {
+        "enabled": true,
+        "title": "Network Services",
+        "description": "These services manage your network connections and internet access.",
+        "question": "Do you need network services for development? (y/N)",
+        "defaultNeeded": true
+      },
+      "storage-opt": {
+        "enabled": true,
+        "title": "Storage Optimization Services",
+        "description": "These services help optimize disk performance and defragment storage.",
+        "question": "Do you need storage optimization for development? (y/N)",
+        "defaultNeeded": false
+      },
+      "telemetry": {
+        "enabled": true,
+        "title": "Diagnostic/Telemetry Services",
+        "description": "These services help Windows diagnose issues and provide feedback.",
+        "question": "Do you want to keep diagnostic services for development? (y/N)",
+        "defaultNeeded": false
+      }
+    }
+  }
+}
+```
+
+## Usage
+
+### Direct Service Assessment
+```powershell
+# Interactive mode for any profile - prompts user based on profile configuration
+powershell -ExecutionPolicy Bypass -File .\assess_services.ps1 -Mode normal -InteractivePrompts
+powershell -ExecutionPolicy Bypass -File .\assess_services.ps1 -Mode gaming -InteractivePrompts
+powershell -ExecutionPolicy Bypass -File .\assess_services.ps1 -Mode dev -InteractivePrompts
+```
+
+### Through Main System Script
+```powershell
+# Run service assessment with interactive prompts based on profile configuration
+powershell -ExecutionPolicy Bypass -File .\system-sanity.ps1 -Profile normal -ServiceAssess -ServiceInteractivePrompts
+powershell -ExecutionPolicy Bypass -File .\system-sanity.ps1 -Profile gaming -ServiceAssess -ServiceInteractivePrompts
+powershell -ExecutionPolicy Bypass -File .\system-sanity.ps1 -Profile dev -ServiceAssess -ServiceInteractivePrompts
+```
+
+## User Experience
+
+When running in interactive mode, users will see prompts configured by the profile:
+
+```
+Interactive Service Configuration for 'normal' Mode
+=================================================
+Configure which services you want to keep running for this mode:
+
+Network Services:
+  These services manage your network connections and internet access.
+Do you need network services for normal use? (y/N)
+
+Audio Services:
+  These services manage audio playback and recording.
+Do you need audio services for normal use? (y/N)
+
+Bluetooth Services:
+  These services manage Bluetooth devices and connections.
+Do you need Bluetooth services for normal use? (y/N)
+```
+
+## Benefits
+
+1. **Profile-Specific Configuration**: Each profile can have different interactive prompts tailored to its use case
+2. **Flexible Schema**: Easy to add new service types or modify existing ones
+3. **Customizable Questions**: Each profile can have custom questions and descriptions
+4. **Default Values**: Profiles can specify sensible defaults for each service type
+5. **Backward Compatibility**: Profiles without InteractivePrompts work as before
+6. **Extensible**: Easy to add new service tags and prompt types
+
+## Implementation Details
+
+### Key Changes Made
+
+1. **Enhanced Profile Schema**: Added `InteractivePrompts` section to profiles.json
+2. **Refactored Interactive Logic**: Moved from hardcoded sections to profile-driven prompts
+3. **Updated Function Names**: Changed from `Get-UserPreferencesForNormal` to `Get-UserPreferencesFromProfile`
+4. **Parameter Renaming**: Changed from `-InteractiveNormal` to `-InteractivePrompts` to reflect broader applicability
+5. **Profile Loading**: Added profile configuration loading in the assessment script
+6. **Default Handling**: Enhanced logic to use profile defaults when user preferences aren't available
+
+### Files Modified
+
+1. **`profiles.json`** - Enhanced with InteractivePrompts metadata for all profiles
+2. **`assess_services.ps1`** - Refactored to use profile-based interactive prompts
+3. **`system-sanity.ps1`** - Updated parameter names and integration
+4. **`test_enhanced_profiles.ps1`** - Test script for the enhanced system
+5. **`ENHANCED_PROFILE_SYSTEM.md`** - This documentation
+
+## Future Enhancements
+
+The enhanced profile system provides a foundation for:
+
+1. **Conditional Prompts**: Prompts that only show under certain conditions
+2. **Profile Inheritance**: Base profiles that other profiles can extend
+3. **User Preference Persistence**: Saving user choices across runs
+4. **Advanced Service Dependencies**: Prompts that consider service relationships
+5. **Custom Service Tags**: User-defined service categories and prompts
+
+This implementation successfully addresses the user's request to move interactive prompt configuration into the profile metadata, making the system more flexible and maintainable.

--- a/ISSUE11_IMPLEMENTATION.md
+++ b/ISSUE11_IMPLEMENTATION.md
@@ -1,0 +1,107 @@
+# Issue 11 Implementation: Expanded "Needed for normal" Designation
+
+## Problem Statement
+Issue 11 requested expanding the "Needed for normal" designation to more services, with the suggestion to ask the user about things like "Do you need airplane mode?" (referring to network services).
+
+## Solution Implemented
+
+### 1. Enhanced Service Assessment Script (`assess_services.ps1`)
+
+#### New Parameter
+- Added `-InteractiveNormal` parameter to enable interactive prompts for additional "normal" services
+
+#### New Functionality
+- **Enhanced Service Tagging**: Added more comprehensive service tags including:
+  - `network`: WiFi, network management, DHCP, DNS cache, network location awareness
+  - `storage-opt`: Disk defragmentation, volume shadow copy services
+  - `audio`: Audio services and audio device management
+  - `bluetooth`: Bluetooth support services
+  - `ui`: Theme and user interface services
+  - `telemetry`: Diagnostic and telemetry services
+
+- **Interactive User Prompts**: New `Get-UserPreferencesForNormal` function that prompts users about:
+  - Network services (WiFi, network management, DHCP)
+  - Storage optimization services
+  - Audio services
+  - Bluetooth services
+  - UI/Theme services
+  - Diagnostic/Telemetry services
+
+- **Enhanced Opinion Matrix**: Updated `Get-Opinion` function to:
+  - Accept user preferences as a parameter
+  - Apply user preferences to determine if services are "Needed for normal"
+  - Provide sensible defaults for each service type
+
+### 2. Enhanced Main Script (`system-sanity.ps1`)
+
+#### New Parameter
+- Added `-ServiceInteractiveNormal` parameter to pass through to the service assessment script
+
+#### Integration
+- Updated service assessment call to pass the new parameter
+- Added usage examples in help text
+
+## Usage Examples
+
+### Direct Service Assessment
+```powershell
+# Interactive mode for Normal profile - prompts user about additional services
+powershell -ExecutionPolicy Bypass -File .\assess_services.ps1 -Mode normal -InteractiveNormal
+
+# With live service detection
+powershell -ExecutionPolicy Bypass -File .\assess_services.ps1 -Mode normal -InteractiveNormal -Live
+```
+
+### Through Main System Script
+```powershell
+# Run service assessment with interactive prompts for additional "normal" services
+powershell -ExecutionPolicy Bypass -File .\system-sanity.ps1 -Profile normal -ServiceAssess -ServiceInteractiveNormal
+```
+
+## User Experience
+
+When running in interactive mode, users will see prompts like:
+
+```
+Additional Services for 'Normal' Mode
+=====================================
+Some services might be useful for normal daily use. Would you like to keep any of these running?
+
+Network Services (WiFi, Network Management, DHCP):
+  These services manage your network connections and internet access.
+Do you need network services for normal use? (y/N)
+
+Audio Services:
+  These services manage audio playback and recording.
+Do you need audio services for normal use? (y/N)
+
+Bluetooth Services:
+  These services manage Bluetooth devices and connections.
+Do you need Bluetooth services for normal use? (y/N)
+```
+
+## Benefits
+
+1. **User Control**: Users can now specify which additional services they want to keep running for "normal" use
+2. **Flexibility**: The system adapts to user preferences rather than using hardcoded assumptions
+3. **Comprehensive Coverage**: Covers network, audio, Bluetooth, UI, and diagnostic services
+4. **Backward Compatibility**: Existing functionality remains unchanged when not using the new parameter
+5. **Clear Documentation**: Each service type is explained to help users make informed decisions
+
+## Files Modified
+
+1. `assess_services.ps1` - Main implementation of interactive prompts and enhanced service assessment
+2. `system-sanity.ps1` - Integration of new parameter and usage examples
+3. `test_issue11.ps1` - Test script to validate the implementation
+4. `ISSUE11_IMPLEMENTATION.md` - This documentation
+
+## Testing
+
+A test script (`test_issue11.ps1`) has been created to validate the functionality. The implementation has been designed to be robust and handle edge cases gracefully.
+
+## Future Enhancements
+
+The framework is extensible and could be enhanced to include:
+- More service types (e.g., security services, backup services)
+- Profile-specific user preferences that persist across runs
+- Integration with the main profile system for automatic service management

--- a/profiles.json
+++ b/profiles.json
@@ -18,7 +18,23 @@
     ],
     "LaunchAppsPost": [
       "Start-Process steam://open/bigpicture"
-    ]
+    ],
+    "InteractivePrompts": {
+      "audio": {
+        "enabled": true,
+        "title": "Audio Services",
+        "description": "These services manage audio playback and recording.",
+        "question": "Do you need audio services for gaming? (y/N)",
+        "defaultNeeded": true
+      },
+      "network": {
+        "enabled": true,
+        "title": "Network Services",
+        "description": "These services manage your network connections and internet access.",
+        "question": "Do you need network services for gaming? (y/N)",
+        "defaultNeeded": true
+      }
+    }
   },
   "dev": {
     "StopServicesPre": [],
@@ -32,7 +48,30 @@
     "LaunchAppsPost": [
       "Start-Process code",
       "Start-Process powershell -ArgumentList '-NoExit -Command cd \"${env:USERPROFILE}\\source\"'"
-    ]
+    ],
+    "InteractivePrompts": {
+      "network": {
+        "enabled": true,
+        "title": "Network Services",
+        "description": "These services manage your network connections and internet access.",
+        "question": "Do you need network services for development? (y/N)",
+        "defaultNeeded": true
+      },
+      "storage-opt": {
+        "enabled": true,
+        "title": "Storage Optimization Services",
+        "description": "These services help optimize disk performance and defragment storage.",
+        "question": "Do you need storage optimization for development? (y/N)",
+        "defaultNeeded": false
+      },
+      "telemetry": {
+        "enabled": true,
+        "title": "Diagnostic/Telemetry Services",
+        "description": "These services help Windows diagnose issues and provide feedback.",
+        "question": "Do you want to keep diagnostic services for development? (y/N)",
+        "defaultNeeded": false
+      }
+    }
   },
   "normal": {
     "StopServicesPre": [],
@@ -41,6 +80,50 @@
       "Discord*"
     ],
     "StartServicesPost": [],
-    "LaunchAppsPost": []
+    "LaunchAppsPost": [],
+    "InteractivePrompts": {
+      "network": {
+        "enabled": true,
+        "title": "Network Services",
+        "description": "These services manage your network connections and internet access.",
+        "question": "Do you need network services for normal use? (y/N)",
+        "defaultNeeded": true
+      },
+      "audio": {
+        "enabled": true,
+        "title": "Audio Services",
+        "description": "These services manage audio playback and recording.",
+        "question": "Do you need audio services for normal use? (y/N)",
+        "defaultNeeded": true
+      },
+      "bluetooth": {
+        "enabled": true,
+        "title": "Bluetooth Services",
+        "description": "These services manage Bluetooth devices and connections.",
+        "question": "Do you need Bluetooth services for normal use? (y/N)",
+        "defaultNeeded": false
+      },
+      "ui": {
+        "enabled": true,
+        "title": "UI/Theme Services",
+        "description": "These services manage visual themes and user interface elements.",
+        "question": "Do you need UI/theme services for normal use? (y/N)",
+        "defaultNeeded": true
+      },
+      "storage-opt": {
+        "enabled": true,
+        "title": "Storage Optimization Services",
+        "description": "These services help optimize disk performance and defragment storage.",
+        "question": "Do you need storage optimization for normal use? (y/N)",
+        "defaultNeeded": false
+      },
+      "telemetry": {
+        "enabled": true,
+        "title": "Diagnostic/Telemetry Services",
+        "description": "These services help Windows diagnose issues and provide feedback.",
+        "question": "Do you want to keep diagnostic services for normal use? (y/N)",
+        "defaultNeeded": false
+      }
+    }
   }
 }

--- a/system-sanity.ps1
+++ b/system-sanity.ps1
@@ -11,6 +11,8 @@
 #     (bypasses menu, uses dev profile directly)
 #   powershell -ExecutionPolicy Bypass -File .\system-sanity.ps1 -ListProfiles
 #     (lists available profiles and exits)
+#   powershell -ExecutionPolicy Bypass -File .\system-sanity.ps1 -Profile normal -ServiceAssess -ServiceInteractiveNormal
+#     (runs service assessment with interactive prompts for additional "normal" services)
 
 param(
   [int]$DurationSecs = 120,
@@ -24,7 +26,8 @@ param(
   [switch]$Capture,           # only collect perf data if explicitly set
   [switch]$ServiceAssess,     # run assess_services.ps1 up front
   [switch]$ServiceApply,      # actually change startup type/stop services
-  [switch]$ServicePromptEach  # prompt per service when applying
+  [switch]$ServicePromptEach, # prompt per service when applying
+  [switch]$ServiceInteractiveNormal  # prompt user for additional "normal" services
 )
 
 $ErrorActionPreference = "Stop"
@@ -298,6 +301,7 @@ if ($Profile -and $ServiceAssess -and (Test-Path $assessScript)) {
   $args = @("-File", $assessScript, "-Mode", $Profile)
   if ($ServiceApply)      { $args += "-Apply" }
   if ($ServicePromptEach) { $args += "-PromptEach" }
+  if ($ServiceInteractiveNormal) { $args += "-InteractiveNormal" }
   # If you prefer to assess the live system even if running-services.csv exists:
   # $args += "-Live"
 

--- a/system-sanity.ps1
+++ b/system-sanity.ps1
@@ -11,8 +11,8 @@
 #     (bypasses menu, uses dev profile directly)
 #   powershell -ExecutionPolicy Bypass -File .\system-sanity.ps1 -ListProfiles
 #     (lists available profiles and exits)
-#   powershell -ExecutionPolicy Bypass -File .\system-sanity.ps1 -Profile normal -ServiceAssess -ServiceInteractiveNormal
-#     (runs service assessment with interactive prompts for additional "normal" services)
+#   powershell -ExecutionPolicy Bypass -File .\system-sanity.ps1 -Profile normal -ServiceAssess -ServiceInteractivePrompts
+#     (runs service assessment with interactive prompts based on profile configuration)
 
 param(
   [int]$DurationSecs = 120,
@@ -27,7 +27,7 @@ param(
   [switch]$ServiceAssess,     # run assess_services.ps1 up front
   [switch]$ServiceApply,      # actually change startup type/stop services
   [switch]$ServicePromptEach, # prompt per service when applying
-  [switch]$ServiceInteractiveNormal  # prompt user for additional "normal" services
+  [switch]$ServiceInteractivePrompts  # prompt user for additional services based on profile configuration
 )
 
 $ErrorActionPreference = "Stop"
@@ -301,7 +301,7 @@ if ($Profile -and $ServiceAssess -and (Test-Path $assessScript)) {
   $args = @("-File", $assessScript, "-Mode", $Profile)
   if ($ServiceApply)      { $args += "-Apply" }
   if ($ServicePromptEach) { $args += "-PromptEach" }
-  if ($ServiceInteractiveNormal) { $args += "-InteractiveNormal" }
+  if ($ServiceInteractivePrompts) { $args += "-InteractivePrompts" }
   # If you prefer to assess the live system even if running-services.csv exists:
   # $args += "-Live"
 

--- a/test_enhanced_profiles.ps1
+++ b/test_enhanced_profiles.ps1
@@ -1,0 +1,125 @@
+# Test script for Enhanced Profile System with Interactive Prompts
+# This script tests the new profile-based interactive prompts functionality
+
+# Mock service data for testing
+$mockServices = @(
+    [PSCustomObject]@{ Name = "WlanSvc"; DisplayName = "WLAN AutoConfig"; Description = "Configures wireless LAN" },
+    [PSCustomObject]@{ Name = "AudioSrv"; DisplayName = "Windows Audio"; Description = "Manages audio devices" },
+    [PSCustomObject]@{ Name = "BthServ"; DisplayName = "Bluetooth Support Service"; Description = "Manages Bluetooth" },
+    [PSCustomObject]@{ Name = "Themes"; DisplayName = "Themes"; Description = "Manages visual themes" },
+    [PSCustomObject]@{ Name = "DiagTrack"; DisplayName = "Connected User Experiences and Telemetry"; Description = "Collects telemetry data" },
+    [PSCustomObject]@{ Name = "DefragSvc"; DisplayName = "Optimize drives"; Description = "Optimizes disk performance" }
+)
+
+# Load the profiles configuration
+$profilesPath = ".\profiles.json"
+if (Test-Path $profilesPath) {
+    $profilesJson = Get-Content $profilesPath -Raw -Encoding UTF8
+    $profiles = $profilesJson | ConvertFrom-Json
+    Write-Host "Loaded profiles: $($profiles.PSObject.Properties.Name -join ', ')" -ForegroundColor Green
+} else {
+    Write-Host "profiles.json not found!" -ForegroundColor Red
+    exit 1
+}
+
+# Include the functions from assess_services.ps1
+. .\assess_services.ps1
+
+Write-Host "Testing Enhanced Profile System with Interactive Prompts" -ForegroundColor Green
+Write-Host "=======================================================" -ForegroundColor Green
+Write-Host ""
+
+# Test 1: Show profile configurations
+Write-Host "Test 1: Profile Configurations" -ForegroundColor Yellow
+foreach ($profileName in $profiles.PSObject.Properties.Name) {
+    $profile = $profiles.$profileName
+    Write-Host "Profile: $profileName" -ForegroundColor White
+    
+    if ($profile.InteractivePrompts) {
+        Write-Host "  Interactive Prompts:" -ForegroundColor Cyan
+        foreach ($promptKey in $profile.InteractivePrompts.PSObject.Properties.Name) {
+            $prompt = $profile.InteractivePrompts.$promptKey
+            $status = if ($prompt.enabled) { "enabled" } else { "disabled" }
+            Write-Host "    $promptKey: $status - '$($prompt.title)'" -ForegroundColor Gray
+        }
+    } else {
+        Write-Host "  No interactive prompts configured" -ForegroundColor Gray
+    }
+    Write-Host ""
+}
+
+# Test 2: Service tagging
+Write-Host "Test 2: Service Tagging" -ForegroundColor Yellow
+foreach ($svc in $mockServices) {
+    $tags = Get-ServiceTags -name $svc.Name -display $svc.DisplayName
+    Write-Host "Service: $($svc.Name) -> Tags: $($tags -join ', ')" -ForegroundColor White
+}
+Write-Host ""
+
+# Test 3: Test different profiles with mock user preferences
+Write-Host "Test 3: Profile-based Opinions" -ForegroundColor Yellow
+
+foreach ($profileName in @("normal", "gaming", "dev")) {
+    if ($profiles.$profileName) {
+        $profile = $profiles.$profileName
+        Write-Host "Testing profile: $profileName" -ForegroundColor White
+        
+        # Mock user preferences (simulating user saying "yes" to all prompts)
+        $mockUserPrefs = @{
+            "network" = $true
+            "audio" = $true
+            "bluetooth" = $false
+            "ui" = $true
+            "storage-opt" = $false
+            "telemetry" = $false
+        }
+        
+        foreach ($svc in $mockServices) {
+            $tags = Get-ServiceTags -name $svc.Name -display $svc.DisplayName
+            $op = Get-Opinion -tags $tags -userPreferences $mockUserPrefs -profileConfig $profile
+            
+            $needed = switch ($profileName) {
+                "dev" { $op.Dev }
+                "gaming" { $op.Gaming }
+                default { $op.Normal }
+            }
+            
+            Write-Host "  $($svc.Name): $needed" -ForegroundColor Gray
+        }
+        Write-Host ""
+    }
+}
+
+# Test 4: Test profile defaults (no user preferences)
+Write-Host "Test 4: Profile Defaults (no user preferences)" -ForegroundColor Yellow
+
+foreach ($profileName in @("normal", "gaming", "dev")) {
+    if ($profiles.$profileName) {
+        $profile = $profiles.$profileName
+        Write-Host "Testing profile: $profileName (defaults only)" -ForegroundColor White
+        
+        foreach ($svc in $mockServices) {
+            $tags = Get-ServiceTags -name $svc.Name -display $svc.DisplayName
+            $op = Get-Opinion -tags $tags -userPreferences @{} -profileConfig $profile
+            
+            $needed = switch ($profileName) {
+                "dev" { $op.Dev }
+                "gaming" { $op.Gaming }
+                default { $op.Normal }
+            }
+            
+            Write-Host "  $($svc.Name): $needed" -ForegroundColor Gray
+        }
+        Write-Host ""
+    }
+}
+
+Write-Host "Enhanced Profile System Test completed successfully!" -ForegroundColor Green
+Write-Host ""
+Write-Host "To use the enhanced functionality:" -ForegroundColor Cyan
+Write-Host "  powershell -ExecutionPolicy Bypass -File .\assess_services.ps1 -Mode normal -InteractivePrompts" -ForegroundColor White
+Write-Host "  powershell -ExecutionPolicy Bypass -File .\assess_services.ps1 -Mode gaming -InteractivePrompts" -ForegroundColor White
+Write-Host "  powershell -ExecutionPolicy Bypass -File .\assess_services.ps1 -Mode dev -InteractivePrompts" -ForegroundColor White
+Write-Host ""
+Write-Host "Through system-sanity.ps1:" -ForegroundColor Cyan
+Write-Host "  powershell -ExecutionPolicy Bypass -File .\system-sanity.ps1 -Profile normal -ServiceAssess -ServiceInteractivePrompts" -ForegroundColor White

--- a/test_issue11.ps1
+++ b/test_issue11.ps1
@@ -1,0 +1,58 @@
+# Test script for Issue 11 - Interactive "Needed for normal" functionality
+# This script tests the new interactive prompts for additional services
+
+# Mock service data for testing
+$mockServices = @(
+    [PSCustomObject]@{ Name = "WlanSvc"; DisplayName = "WLAN AutoConfig"; Description = "Configures wireless LAN" },
+    [PSCustomObject]@{ Name = "AudioSrv"; DisplayName = "Windows Audio"; Description = "Manages audio devices" },
+    [PSCustomObject]@{ Name = "BthServ"; DisplayName = "Bluetooth Support Service"; Description = "Manages Bluetooth" },
+    [PSCustomObject]@{ Name = "Themes"; DisplayName = "Themes"; Description = "Manages visual themes" },
+    [PSCustomObject]@{ Name = "DiagTrack"; DisplayName = "Connected User Experiences and Telemetry"; Description = "Collects telemetry data" }
+)
+
+# Include the functions from assess_services.ps1
+. .\assess_services.ps1
+
+Write-Host "Testing Issue 11 - Interactive 'Needed for normal' functionality" -ForegroundColor Green
+Write-Host "=================================================================" -ForegroundColor Green
+Write-Host ""
+
+# Test 1: Get service tags
+Write-Host "Test 1: Service Tagging" -ForegroundColor Yellow
+foreach ($svc in $mockServices) {
+    $tags = Get-ServiceTags -name $svc.Name -display $svc.DisplayName
+    Write-Host "Service: $($svc.Name) -> Tags: $($tags -join ', ')" -ForegroundColor White
+}
+Write-Host ""
+
+# Test 2: Get opinions without user preferences
+Write-Host "Test 2: Default Opinions (no user preferences)" -ForegroundColor Yellow
+foreach ($svc in $mockServices) {
+    $tags = Get-ServiceTags -name $svc.Name -display $svc.DisplayName
+    $op = Get-Opinion -tags $tags
+    Write-Host "Service: $($svc.Name) -> Normal: $($op.Normal)" -ForegroundColor White
+}
+Write-Host ""
+
+# Test 3: Get opinions with user preferences
+Write-Host "Test 3: Opinions with User Preferences" -ForegroundColor Yellow
+$userPrefs = @{
+    "network" = $true
+    "audio" = $true
+    "bluetooth" = $false
+    "ui" = $true
+    "telemetry" = $false
+}
+
+foreach ($svc in $mockServices) {
+    $tags = Get-ServiceTags -name $svc.Name -display $svc.DisplayName
+    $op = Get-Opinion -tags $tags -userPreferences $userPrefs
+    Write-Host "Service: $($svc.Name) -> Normal: $($op.Normal)" -ForegroundColor White
+}
+Write-Host ""
+
+Write-Host "Test completed successfully!" -ForegroundColor Green
+Write-Host ""
+Write-Host "To use the new functionality:" -ForegroundColor Cyan
+Write-Host "  powershell -ExecutionPolicy Bypass -File .\assess_services.ps1 -Mode normal -InteractiveNormal" -ForegroundColor White
+Write-Host "  powershell -ExecutionPolicy Bypass -File .\system-sanity.ps1 -Profile normal -ServiceAssess -ServiceInteractiveNormal" -ForegroundColor White


### PR DESCRIPTION
Add interactive prompts for "Needed for normal" service assessment to allow users to customize essential services.

This PR implements interactive user prompts for the `normal` service assessment profile, allowing users to define which additional services (e.g., network, audio, Bluetooth) are considered 'needed'. This directly addresses issue #11, which requested expanding the "Needed for normal" designation with user input, specifically mentioning network-related services.

---
<a href="https://cursor.com/background-agent?bcId=bc-2bbe4074-81d3-4ebe-97da-d9eb0429532d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2bbe4074-81d3-4ebe-97da-d9eb0429532d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

